### PR TITLE
chore: add MI to title and branch patterns [MI-20]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,11 @@ inputs:
   title-regex:
     description: 'Title regex to match'
     required: true
-    default: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps){1}(\([\w-\.]+\))?(!)?:\ ([\w\ ])+([\s\S]*)\[MT-\d+\]'
+    default: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps){1}(\([\w-\.]+\))?(!)?:\ ([\w\ ])+([\s\S]*)\[(MT|MI)-\d+\]'
   branch-regex:
     description: 'Title regex to match'
     required: true
-    default: 'MT-\d+'
+    default: '(MT|MI)-\d+'
 outputs:
   time: # id of output
     description: "The time we greeted you"


### PR DESCRIPTION
Now that have the integrations dashboard, we should allow PRs that contain both MT-XXXX and MI-XXXX.