### PR TITLE
feat: validate that the `ticket id` in the PR title is part of the branch name [PD-202]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Lints PRs to comply with our convention.
 
 Requires node version >= 21
 
-`npm run tes`
+`npm run test`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # pr-lint
 
 Lints PRs to comply with our convention.
+
+## Running unit tests
+
+Requires node version >= 21
+
+`npm run tes`

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,11 @@ inputs:
   title-regex:
     description: "Title regex to match"
     required: true
-    default: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps){1}(\([\w-\.]+\))?(!)?:\ ([\w\ ])+([\s\S]*)\[(MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\d+\]'
+    default: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps){1}(\([\w\.-]+\))?(!)?:\ ([\w\ ])+([\s\S]*)\[(MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\d+\]$'
   branch-regex:
     description: "Title regex to match"
     required: true
-    default: '(MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\d+'
+    default: '(?:MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\d+(?:-\d+)?$'
 outputs:
   time: # id of output
     description: "The time we greeted you"

--- a/index.js
+++ b/index.js
@@ -1,37 +1,32 @@
-const core = require('@actions/core');
-const github = require('@actions/github');
+const core = require("@actions/core");
+const github = require("@actions/github");
 
-try {
-  const titleRegexString = core.getInput('title-regex', { required: true });
-  const titleRegexFlagsString = core.getInput('title-regex-flags') || 'g';
-  const branchRegexString = core.getInput('branch-regex', { required: true });
-  const branchRegexFlagsString = core.getInput('branch-regex-flags') || 'g';
+const { validateTitleAndBranch } = require("./methods");
+
+function main() {
+  const titleRegexString = core.getInput("title-regex", { required: true });
+  const branchRegexString = core.getInput("branch-regex", { required: true });
 
   const title = String(github.context.payload.pull_request.title);
   const branch = String(github.context.payload.pull_request.head.ref);
-  const titleRegex = new RegExp(titleRegexString, titleRegexFlagsString)
-  const branchRegex = new RegExp(branchRegexString, branchRegexFlagsString)
+  const titleRegex = new RegExp(titleRegexString);
+  const branchRegex = new RegExp(branchRegexString);
 
   core.info(`Title: ${title}`);
   core.info(`Title Regex: ${titleRegex}`);
-
   core.info(`Branch: ${branch}`);
   core.info(`Branch Regex: ${branchRegex}`);
 
+  const error = validateTitleAndBranch({
+    branch,
+    branchRegex,
+    title,
+    titleRegex,
+  });
 
-  if (!branchRegex.test(branch)) {
-    core.setFailed('Branch doesn\'t match given regex.');
+  if (error) {
+    core.setFailed(error);
   }
-
-  if (!titleRegex.test(title)) {
-    core.setFailed('Title doesn\'t match given regex.');
-  }
-
-  if (!title.includes(branch)) {
-    core.setFailed('Title and branch are inconsistent');
-  }
-
-
-} catch (error) {
-  core.setFailed(error.message);
 }
+
+main();

--- a/index.spec.js
+++ b/index.spec.js
@@ -15,26 +15,42 @@ describe("validateTitleAndBranch", () => {
   const titleRegex = new RegExp(titleRegexString);
   const branchRegex = new RegExp(branchRegexString);
 
-  it("should return error when the title does not match the regex pattern", () => {
-    const result = validateTitleAndBranch({
-      branch: "PD-200",
-      branchRegex,
-      title: "Invalid title",
-      titleRegex,
-    });
+  describe("invalid title", () => {
+    [
+      "invalid title",
+      "feat(): description [PD-200]",
+      "feat(test): description [PD-200-0001]",
+      "feat(test): description",
+      "feat(test): description PD-200",
+    ].forEach((title) => {
+      it(`should return error when the title does not match the regex pattern: ${title}`, () => {
+        const result = validateTitleAndBranch({
+          branch: "PD-200",
+          branchRegex,
+          title,
+          titleRegex,
+        });
 
-    assert.strictEqual(result, "Title doesn't match given regex.");
+        assert.strictEqual(result, "Title doesn't match given regex.");
+      });
+    });
   });
 
-  it("should return error when the branch does not match the regex pattern", () => {
-    const result = validateTitleAndBranch({
-      branch: "invalid-branch",
-      branchRegex,
-      title: "feat(test): description [PD-200]",
-      titleRegex,
-    });
+  describe("invalid branch", () => {
+    ["invalid-branch", "PD-200-", "PD-200PD", "PD200", "200"].forEach(
+      (branch) => {
+        it(`should return error when the branch does not match the regex pattern: ${branch}`, () => {
+          const result = validateTitleAndBranch({
+            branch,
+            branchRegex,
+            title: "feat(test): description [PD-200]",
+            titleRegex,
+          });
 
-    assert.strictEqual(result, "Branch doesn't match given regex.");
+          assert.strictEqual(result, "Branch doesn't match given regex.");
+        });
+      }
+    );
   });
 
   describe("branch / title inconsistencies", () => {
@@ -54,16 +70,16 @@ describe("validateTitleAndBranch", () => {
         assert.strictEqual(result, "Title and branch are inconsistent");
       });
     });
+  });
 
-    it("should not return error when the title and branch are consistent", () => {
-      const result = validateTitleAndBranch({
-        branch: "PD-200",
-        branchRegex,
-        title: "feat(test): description xpto 123 [PD-200]",
-        titleRegex,
-      });
-
-      assert.strictEqual(result, undefined);
+  it("should not return error when the title and branch are consistent", () => {
+    const result = validateTitleAndBranch({
+      branch: "PD-200-001",
+      branchRegex,
+      title: "feat(test): description xpto 123 [PD-200]",
+      titleRegex,
     });
+
+    assert.strictEqual(result, undefined);
   });
 });

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,0 +1,69 @@
+const core = require("@actions/core");
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+
+const { validateTitleAndBranch } = require("./methods");
+
+describe("validateTitleAndBranch", () => {
+  process.env["INPUT_TITLE-REGEX"] =
+    "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps){1}(\\([\\w\\.-]+\\))?(!)?:\\ ([\\w\\ ])+([\\s\\S]*)\\[(MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\\d+\\]";
+  process.env["INPUT_BRANCH-REGEX"] =
+    "^(?:MT|MI|INT|CT|HF|DB|RI|MN|MP|PD)-\\d+(?:-\\d+)?$";
+
+  const titleRegexString = core.getInput("title-regex", { required: true });
+  const branchRegexString = core.getInput("branch-regex", { required: true });
+  const titleRegex = new RegExp(titleRegexString);
+  const branchRegex = new RegExp(branchRegexString);
+
+  it("should return error when the title does not match the regex pattern", () => {
+    const result = validateTitleAndBranch({
+      branch: "PD-200",
+      branchRegex,
+      title: "Invalid title",
+      titleRegex,
+    });
+
+    assert.strictEqual(result, "Title doesn't match given regex.");
+  });
+
+  it("should return error when the branch does not match the regex pattern", () => {
+    const result = validateTitleAndBranch({
+      branch: "invalid-branch",
+      branchRegex,
+      title: "feat(test): description [PD-200]",
+      titleRegex,
+    });
+
+    assert.strictEqual(result, "Branch doesn't match given regex.");
+  });
+
+  describe("branch / title inconsistencies", () => {
+    [
+      ["PD-200", "feat(test): description [PD-201]"],
+      ["PD-200-200", "feat(test): description [PD-201]"],
+      ["PD-200-200", "feat(test): description [PD-201]"],
+    ].forEach(([branch, title]) => {
+      it(`should return error when the title and branch are inconsistent`, () => {
+        const result = validateTitleAndBranch({
+          branch,
+          branchRegex,
+          title,
+          titleRegex,
+        });
+
+        assert.strictEqual(result, "Title and branch are inconsistent");
+      });
+    });
+
+    it("should not return error when the title and branch are consistent", () => {
+      const result = validateTitleAndBranch({
+        branch: "PD-200",
+        branchRegex,
+        title: "feat(test): description xpto 123 [PD-200]",
+        titleRegex,
+      });
+
+      assert.strictEqual(result, undefined);
+    });
+  });
+});

--- a/methods.js
+++ b/methods.js
@@ -8,11 +8,9 @@ function validateTitleAndBranch({ branch, branchRegex, title, titleRegex }) {
       return "Title doesn't match given regex.";
     }
 
-    // Extract the issue number from the title using regex
     const issueNumberMatches = title.match(/\[(\w+-\d+)\]/);
     const issueNumber = issueNumberMatches ? issueNumberMatches[1] : null;
 
-    // Check if the branch is a substring of the title and it matches the issue number format
     if (
       !issueNumber ||
       (branch !== issueNumber && !branch.startsWith(issueNumber + "-"))

--- a/methods.js
+++ b/methods.js
@@ -1,0 +1,29 @@
+function validateTitleAndBranch({ branch, branchRegex, title, titleRegex }) {
+  try {
+    if (branchRegex.test(branch) === false) {
+      return "Branch doesn't match given regex.";
+    }
+
+    if (titleRegex.test(title) === false) {
+      return "Title doesn't match given regex.";
+    }
+
+    // Extract the issue number from the title using regex
+    const issueNumberMatches = title.match(/\[(\w+-\d+)\]/);
+    const issueNumber = issueNumberMatches ? issueNumberMatches[1] : null;
+
+    // Check if the branch is a substring of the title and it matches the issue number format
+    if (
+      !issueNumber ||
+      (branch !== issueNumber && !branch.startsWith(issueNumber + "-"))
+    ) {
+      return "Title and branch are inconsistent";
+    }
+  } catch (error) {
+    return error.message;
+  }
+}
+
+module.exports = {
+  validateTitleAndBranch,
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "ncc build index.js --license licenses.txt",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node index.spec.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR aims to:
- allow branch names to be in the format e.g. `PD-200-01` to enable multiple PRs for the same ticket
- validate that the `ticket id` is part of the branch name
- rework the code to make it more modular and testable
- add unit tests
![Screenshot 2024-03-04 at 17 11 13](https://github.com/MobieTrain/pr-lint/assets/9081358/04e28acd-d742-424b-9067-b4ee943f056e)

